### PR TITLE
FastAnonymous doesn't work on Julia v0.5-

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4-
+julia 0.4- 0.5-
 Compat
 Debug


### PR DESCRIPTION
```
> g = @anon x->(x+offset)^2

ERROR: eval cannot be used in a generated function
 in getclosure(::Tuple{Symbol}, ::SimpleVector) at /Users/johan/.julia/v0.5/FastAnonymous/src/FastAnonymous.jl:110
 in closure(...) at /Users/johan/.julia/v0.5/FastAnonymous/src/FastAnonymous.jl:86
```

It does work if offset is hardcoded (`g = @anon x->(x+1.2)^2`). But that doesn't provide any speed-improvement, v0.5 is just as fast on its own.
